### PR TITLE
Add typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,29 @@
+import React from "react";
+import { StyleProp, ViewStyle, TextStyle } from "react-native";
+
+interface IconDetail {
+  family: string;
+  color?: string;
+  icons: string[];
+}
+
+interface Icon {
+  icon: string;
+  family: string;
+  color: string;
+}
+
+interface IconPickerProps {
+  headerTitle?: string;
+  showIconPicker: boolean;
+  onSelect: (icon: Icon) => void;
+  toggleIconPicker: () => void;
+  iconDetails: IconDetail[];
+  content?: React.ReactNode;
+  selectedIcon?: Icon;
+  selectedIconContainerStyle?: StyleProp<ViewStyle>;
+}
+
+declare class IconPicker extends React.Component<IconPickerProps, any> {}
+
+export default IconPicker;

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
   "homepage": "https://github.com/kawaljain/react-native-icon-picker#readme",
   "dependencies": {
     "react-native-vector-icons": "^8.1.0"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
Hello @kawaljain,

I've noticed that the `react-native-icon-picker` package currently lacks TypeScript type definitions, which can be a hurdle for TypeScript developers seeking to leverage strong typing in their projects. To address this, I have contributed a TypeScript declaration file (`index.d.ts`) that provides type definitions for the `IconPicker` component and its associated props. This addition aims to enhance the developer experience for those using TypeScript, offering improved code reliability and ease of use.

Additionally, I've updated the `package.json` to include the type declaration file, ensuring seamless integration for TypeScript users. These changes do not impact the existing JavaScript functionality but extend the package's usability to a broader audience.

I hope you find these additions valuable and look forward to any feedback or suggestions you might have.

Best regards,
Mikael Grön